### PR TITLE
Add transparent model renderer with gradient

### DIFF
--- a/pagina_apoyo/src/components/ModelRenderer.jsx
+++ b/pagina_apoyo/src/components/ModelRenderer.jsx
@@ -3,7 +3,7 @@ import * as THREE from 'three'
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 
-function ModelRenderer({ src }) {
+function ModelRenderer({ src, className = '', style = {} }) {
   const containerRef = useRef(null)
 
   useEffect(() => {
@@ -19,23 +19,47 @@ function ModelRenderer({ src }) {
     )
     camera.position.set(0, 1, 3)
 
-    const renderer = new THREE.WebGLRenderer({ antialias: true })
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true })
+    renderer.setClearColor(0x000000, 0)
     renderer.setSize(container.clientWidth, container.clientHeight)
     renderer.setPixelRatio(window.devicePixelRatio)
+    renderer.shadowMap.enabled = true
+    renderer.domElement.style.position = 'absolute'
+    renderer.domElement.style.inset = 0
     container.appendChild(renderer.domElement)
 
     const controls = new OrbitControls(camera, renderer.domElement)
     controls.enableDamping = true
 
-    const light = new THREE.HemisphereLight(0xffffff, 0x444444)
-    light.position.set(0, 1, 0)
-    scene.add(light)
+    const ambient = new THREE.HemisphereLight(0xffffff, 0x444444)
+    ambient.position.set(0, 1, 0)
+    scene.add(ambient)
+
+    const dirLight = new THREE.DirectionalLight(0xffffff, 1)
+    dirLight.position.set(2, 4, 2)
+    dirLight.castShadow = true
+    dirLight.shadow.bias = -0.0001
+    scene.add(dirLight)
+
+    const shadowPlane = new THREE.PlaneGeometry(10, 10)
+    const shadowMaterial = new THREE.ShadowMaterial({ opacity: 0.2 })
+    const plane = new THREE.Mesh(shadowPlane, shadowMaterial)
+    plane.rotation.x = -Math.PI / 2
+    plane.position.y = -0.01
+    plane.receiveShadow = true
+    scene.add(plane)
 
     const loader = new GLTFLoader()
     let model
 
     loader.load(src, (gltf) => {
       model = gltf.scene
+      model.traverse((child) => {
+        if (child.isMesh) {
+          child.castShadow = true
+          child.receiveShadow = true
+        }
+      })
       scene.add(model)
     })
 
@@ -65,7 +89,24 @@ function ModelRenderer({ src }) {
     }
   }, [src])
 
-  return <div ref={containerRef} style={{ width: '100%', height: '400px' }} />
+  return (
+    <div
+      ref={containerRef}
+      className={`model-container ${className}`}
+      style={{ position: 'relative', width: '100%', aspectRatio: '1 / 1', ...style }}
+    >
+      <div
+        className="model-gradient"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          background:
+            'linear-gradient(135deg, rgba(255,255,255,0.8), rgba(200,200,200,0.8))',
+          zIndex: 0,
+        }}
+      />
+    </div>
+  )
 }
 
 export default ModelRenderer

--- a/pagina_apoyo/src/styles/App.css
+++ b/pagina_apoyo/src/styles/App.css
@@ -8,3 +8,17 @@
   box-sizing: border-box;
   padding: 1rem;
 }
+
+.model-container canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+}
+
+.model-container .model-gradient {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}


### PR DESCRIPTION
## Summary
- make ModelRenderer transparent and square
- add lighting and shadow support
- overlay HTML gradient behind the canvas
- style canvas overlay

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683fa3f636f4833296ded4a96aeb8b4c